### PR TITLE
Support overlays on multiple OSD viewers

### DIFF
--- a/openseadragon-paperjs-overlay.js
+++ b/openseadragon-paperjs-overlay.js
@@ -45,6 +45,7 @@
         this.resize();
 
         paper.setup(this._canvas);
+        this._project = paper.project;
 
         this._viewer.addHandler('update-viewport', function() {
             self.resize();
@@ -82,6 +83,7 @@
             }
         },
         resizecanvas: function() {
+                this._project.activate();
                 this._canvasdiv.setAttribute('width', this._containerWidth);
                 this._canvas.setAttribute('width', this._containerWidth);
                 this._canvasdiv.setAttribute('height', this._containerHeight);


### PR DESCRIPTION
Paperjs will draw on the last project created with setup(canvas). If
there are multiple OSD viewers with multiple canvases, say in different
tabs, then resizecanvas() may work against the wrong paper.view. Store
the project for each overlay and activate() it at the top of
resizecanvas().